### PR TITLE
add helm pre-install hook for certificate setup

### DIFF
--- a/helm/xliic-injector/Chart.yaml
+++ b/helm/xliic-injector/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: xliic-injector
 description: A Helm chart to install 42Crunch Kubernetes Injector
 type: application
-version: 1.0.0
+version: 1.0.1
 appVersion: 1.0.0

--- a/helm/xliic-injector/templates/deployment.yaml
+++ b/helm/xliic-injector/templates/deployment.yaml
@@ -41,4 +41,8 @@ spec:
       volumes:
         - name: webhook-certs
           secret:
+            {{- if not .Values.csrHook.enabled }}
             secretName: {{ .Values.injector.tlsSecret }}
+            {{- else }}
+            secretName: {{ .Values.app.name }}-webhook-certs
+            {{- end }}

--- a/helm/xliic-injector/templates/hooks/pre-install-jobs.yaml
+++ b/helm/xliic-injector/templates/hooks/pre-install-jobs.yaml
@@ -1,0 +1,140 @@
+{{- if .Values.csrHook.enabled }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Values.app.name }}-cert-setup
+  labels:
+    app: {{ .Values.app.name }}-cert-setup
+{{- include "xliic-injector.labels" . | nindent 4 }}
+  annotations:
+    helm.sh/hook: pre-install, pre-upgrade
+    helm.sh/hook-weight: "0"
+spec:
+  template:
+    metadata:
+      name: {{ .Values.app.name }}-cert-setup
+      labels:
+        app: {{ .Values.app.name }}-cert-setup
+    spec:
+      restartPolicy: Never
+      serviceAccountName: {{ .Values.app.name }}-cert-setup
+      containers:
+        - name: {{ .Values.app.name }}-cert-setup
+          image: {{ .Values.csrHook.image }}
+          imagePullPolicy: {{ .Values.csrHook.pullPolicy }}
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - |
+              set -e
+
+              # Fully qualified name of the CSR object
+              certApi="certificates.k8s.io"
+              certApiVersion="v1"
+              csrApi="certificatesigningrequests.${certApiVersion}.${certApi}"
+
+              secret={{ .Values.app.name }}-webhook-certs
+              service={{ .Values.service.name }}
+              namespace={{ .Release.Namespace }}
+
+              fullServiceDomain="${service}.${namespace}.svc"
+              # THE CN has a limit of 64 characters. We could remove the namespace and svc
+              # and rely on the Subject Alternative Name (SAN), but there is a bug in EKS
+              # that discards the SAN when signing the certificates.
+              #
+              # https://github.com/awslabs/amazon-eks-ami/issues/341
+              if [ ${#fullServiceDomain} -gt 64 ] ; then
+                echo "ERROR: common name exceeds the 64 character limit: ${fullServiceDomain}"
+                exit 1
+              fi
+
+              tmpdir=$(mktemp -d)
+              echo "INFO: creating certs in tmpdir ${tmpdir} "
+
+              cat <<EOF >> "${tmpdir}/csr.conf"
+              [req]
+              req_extensions = v3_req
+              distinguished_name = req_distinguished_name
+              [req_distinguished_name]
+              [ v3_req ]
+              basicConstraints = CA:FALSE
+              keyUsage = nonRepudiation, digitalSignature, keyEncipherment
+              extendedKeyUsage = serverAuth
+              subjectAltName = @alt_names
+              [alt_names]
+              DNS.1 = ${service}
+              DNS.2 = ${service}.${namespace}
+              DNS.3 = ${fullServiceDomain}
+              EOF
+
+              openssl genrsa -out "${tmpdir}/server-key.pem" 2048
+              openssl req -new -key "${tmpdir}/server-key.pem" -subj "/CN=system:node:${fullServiceDomain}/O=system:nodes" -out "${tmpdir}/server.csr" -config "${tmpdir}/csr.conf"
+
+              csrName={{ .Values.app.name }}-csr
+              echo "INFO: creating csr: ${csrName} "
+              set +e
+
+              # clean-up any previously created CSR for our service. Ignore errors if not present.
+              kubectl delete "${csrApi}/${csrName}" 2>/dev/null || true
+              set -e
+
+              # create server cert/key CSR and send it to k8s api
+              cat <<EOF | kubectl create --validate=false -f -
+              apiVersion: ${certApi}/${certApiVersion}
+              kind: CertificateSigningRequest
+              metadata:
+                name: ${csrName}
+              spec:
+                signerName: kubernetes.io/kubelet-serving
+                groups:
+                  - system:authenticated
+                request: $(base64 < "${tmpdir}/server.csr" | tr -d '\n')
+                usages:
+                  - digital signature
+                  - key encipherment
+                  - server auth
+              EOF
+              set +e
+
+              # verify CSR has been created
+              while true; do
+                if kubectl get "${csrApi}/${csrName}"; then
+                    break
+                fi
+              done
+              set -e
+
+              # approve and fetch the signed certificate
+              kubectl certificate approve "${csrApi}/${csrName}"
+              set +e
+
+              # verify certificate has been signed
+              i=1
+              while [ "$i" -ne 20 ]
+              do
+                serverCert=$(kubectl get "${csrApi}/${csrName}" -o jsonpath='{.status.certificate}')
+                if [ "${serverCert}" != '' ]; then
+                    break
+                fi
+                sleep 3
+                i=$((i + 1))
+              done
+              set -e
+
+              if [ "${serverCert}" = '' ]; then
+                echo "ERROR: After approving csr ${csrName}, the signed certificate did not appear on the resource. Giving up after 1 minute." >&2
+                exit 1
+              fi
+
+              echo "${serverCert}" | openssl base64 -d -A -out "${tmpdir}/server-cert.pem"
+
+              # create the secret with CA cert and server cert/key
+              kubectl create secret tls "${secret}" \
+                  --key="${tmpdir}/server-key.pem" \
+                  --cert="${tmpdir}/server-cert.pem" \
+                  --dry-run=client -o yaml \
+              | kubectl label -f- --dry-run=client -o yaml --local \
+                  app={{ .Values.app.name }} \
+              | kubectl -n "${namespace}" apply -f -
+{{- end }}

--- a/helm/xliic-injector/templates/hooks/rbac.yaml
+++ b/helm/xliic-injector/templates/hooks/rbac.yaml
@@ -84,6 +84,14 @@ rules:
       - secrets
     verbs:
       - create
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    resourceNames:
+      - {{ .Values.app.name }}-webhook-certs
+    verbs:
+      - patch
       - get
 ---
 kind: RoleBinding

--- a/helm/xliic-injector/templates/hooks/rbac.yaml
+++ b/helm/xliic-injector/templates/hooks/rbac.yaml
@@ -1,0 +1,105 @@
+{{- if .Values.csrHook.enabled }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ .Values.app.name }}-cert-setup
+  annotations:
+    helm.sh/hook: pre-install, pre-upgrade
+    helm.sh/hook-weight: "-5"
+  labels:
+    {{- include "xliic-injector.labels" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ .Values.app.name }}-csr
+  annotations:
+    helm.sh/hook: pre-install, pre-upgrade
+    helm.sh/hook-weight: "-5"
+  labels:
+    {{- include "xliic-injector.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - certificatesigningrequests
+    resourceNames:
+      - {{ .Values.app.name }}-csr
+    verbs:
+      - get
+      - delete
+      - watch
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - certificatesigningrequests
+    verbs:
+      - create
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - certificatesigningrequests/approval
+    verbs:
+      - update
+  - apiGroups:
+      - certificates.k8s.io
+    resources:
+      - signers
+    resourceNames:
+      - kubernetes.io/kubelet-serving
+    verbs:
+      - approve
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ .Values.app.name }}-csr
+  annotations:
+    helm.sh/hook: pre-install, pre-upgrade
+    helm.sh/hook-weight: "-5"
+  labels:
+    {{- include "xliic-injector.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ .Values.app.name }}-csr
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.app.name }}-cert-setup
+    namespace: {{ .Release.Namespace }}
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Values.app.name }}-cert-setup
+  annotations:
+    helm.sh/hook: pre-install, pre-upgrade
+    helm.sh/hook-weight: "-5"
+  labels:
+    {{- include "xliic-injector.labels" . | nindent 4 }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - create
+      - get
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: {{ .Values.app.name }}-cert-setup
+  annotations:
+    helm.sh/hook: pre-install, pre-upgrade
+    helm.sh/hook-weight: "-5"
+  labels:
+    {{- include "xliic-injector.labels" . | nindent 4 }}
+roleRef:
+  kind: Role
+  name: {{ .Values.app.name }}-cert-setup
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+  - kind: ServiceAccount
+    name: {{ .Values.app.name }}-cert-setup
+{{- end }}

--- a/helm/xliic-injector/templates/mutating-webhook-configuration.yaml
+++ b/helm/xliic-injector/templates/mutating-webhook-configuration.yaml
@@ -1,8 +1,16 @@
-
-{{- $altNames := list ( printf "%s.%s" .Values.service.name .Release.Namespace ) ( printf "%s.%s.svc" .Values.service.name .Release.Namespace ) -}}
-{{- $ca := genCA "xliic-injector-ca" 365 -}}
-{{- $cert := genSignedCert ( printf "%s.%s" .Values.service.name .Release.Namespace ) nil $altNames 365 $ca -}}
-{{- $caCert := $ca.Cert -}}
+{{- $cert := "" }}
+{{- $caCert := "" }}
+{{- if .Values.csrHook.enabled }}
+  {{- $ca := (lookup "v1" "ConfigMap" "kube-system" "kube-root-ca.crt") }}
+  {{- if $ca }}
+  {{- $caCert = index $ca.data "ca.crt" }}
+  {{- end }}
+{{- else }}
+  {{- $altNames := list ( printf "%s.%s" .Values.service.name .Release.Namespace ) ( printf "%s.%s.svc" .Values.service.name .Release.Namespace ) -}}
+  {{- $ca := genCA "xliic-injector-ca" 365 -}}
+  {{- $cert = genSignedCert ( printf "%s.%s" .Values.service.name .Release.Namespace ) nil $altNames 365 $ca -}}
+  {{- $caCert = $ca.Cert -}}
+{{- end }}
 apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
@@ -32,6 +40,7 @@ webhooks:
     sideEffects: None
     admissionReviewVersions: ["v1", "v1beta1"]
 ---
+{{- if not .Values.csrHook.enabled }}
 apiVersion: v1
 kind: Secret
 type: kubernetes.io/tls
@@ -43,3 +52,4 @@ metadata:
 data:
   tls.crt: {{ $cert.Cert | b64enc }}
   tls.key: {{ $cert.Key | b64enc }}
+{{- end }}

--- a/helm/xliic-injector/values.yaml
+++ b/helm/xliic-injector/values.yaml
@@ -29,5 +29,5 @@ apifirewall:
 
 csrHook:
   enabled: true
-  image: rainchei/k8s-openssl:latest
+  image: 42crunch/k8s-openssl:latest
   pullPolicy: IfNotPresent

--- a/helm/xliic-injector/values.yaml
+++ b/helm/xliic-injector/values.yaml
@@ -26,3 +26,8 @@ apifirewall:
   maxCpu: 500m
   maxMemory: 500Mi
   platform: protection.42crunch.com:8001
+
+csrHook:
+  enabled: true
+  image: rainchei/k8s-openssl:latest
+  pullPolicy: IfNotPresent

--- a/k8s-openssl/Dockerfile
+++ b/k8s-openssl/Dockerfile
@@ -1,0 +1,15 @@
+FROM alpine:3.16
+
+# This makes it easy to build tagged images with different `kubectl` versions.
+ARG KUBECTL_VERSION="v1.24.3"
+
+# Set by docker automatically
+ARG TARGETOS
+ARG TARGETARCH
+
+RUN apk --upgrade --no-cache add openssl && \
+    wget "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/${TARGETOS}/${TARGETARCH}/kubectl" && \
+    chmod +x ./kubectl && mv ./kubectl /usr/local/bin/kubectl
+
+WORKDIR /app
+USER 1000

--- a/k8s-openssl/Makefile
+++ b/k8s-openssl/Makefile
@@ -2,6 +2,13 @@ DOCKER_IMAGE_NAME ?= rainchei/k8s-openssl
 DOCKER_IMAGE_TAG ?= latest
 KUBECTL_VERSION ?= v1.24.3
 
+.PHONY: all
+all: build inspect
+
 .PHONY: build
 build:
-	docker build -t $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) .
+	docker buildx build -t $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) --build-arg KUBECTL_VERSION=$(KUBECTL_VERSION) --platform linux/amd64,linux/arm64 --push .
+
+.PHONY: inspect
+inspect:
+	docker buildx imagetools inspect $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG)

--- a/k8s-openssl/Makefile
+++ b/k8s-openssl/Makefile
@@ -1,4 +1,4 @@
-DOCKER_IMAGE_NAME ?= rainchei/k8s-openssl
+DOCKER_IMAGE_NAME ?= 42crunch/k8s-openssl
 DOCKER_IMAGE_TAG ?= latest
 KUBECTL_VERSION ?= v1.24.3
 

--- a/k8s-openssl/Makefile
+++ b/k8s-openssl/Makefile
@@ -1,0 +1,7 @@
+DOCKER_IMAGE_NAME ?= rainchei/k8s-openssl
+DOCKER_IMAGE_TAG ?= latest
+KUBECTL_VERSION ?= v1.24.3
+
+.PHONY: build
+build:
+	docker build -t $(DOCKER_IMAGE_NAME):$(DOCKER_IMAGE_TAG) .


### PR DESCRIPTION
Add a pre-install hook to execute a script for certificate setup, this is a detailed list of steps the script is executing:

- Generate a server key.
- If there is any previous CSR (certificate signing request) for this key, it is deleted.
- Generate a CSR for such key.
- The signature of the key is then approved.
- The server's certificate is fetched from the CSR and then encoded.
- A secret of type tls is created with the server certificate and key.